### PR TITLE
fix: replace Zend_HTTP to Laminas_HTTP

### DIFF
--- a/Model/Services/AddToCart.php
+++ b/Model/Services/AddToCart.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 use Magento\Framework\Model\AbstractModel;
 
 /**
@@ -27,7 +26,7 @@ class AddToCart extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::POST;
+        return \Laminas\Http\Request::METHOD_POST;
     }
 
     /**

--- a/Model/Services/Agencies.php
+++ b/Model/Services/Agencies.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class Agencies
@@ -26,7 +25,7 @@ class Agencies extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::GET;
+        return \Laminas\Http\Request::METHOD_GET;
     }
 
     /**

--- a/Model/Services/Balance.php
+++ b/Model/Services/Balance.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class Balance
@@ -26,7 +25,7 @@ class Balance extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::GET;
+        return \Laminas\Http\Request::METHOD_GET;
     }
 
     /**

--- a/Model/Services/Cancel.php
+++ b/Model/Services/Cancel.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class Cancel
@@ -26,7 +25,7 @@ class Cancel extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::POST;
+        return \Laminas\Http\Request::METHOD_POST;
     }
 
     /**

--- a/Model/Services/Cart.php
+++ b/Model/Services/Cart.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class Cart
@@ -26,7 +25,7 @@ class Cart extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::GET;
+        return \Laminas\Http\Request::METHOD_GET;
     }
 
     /**

--- a/Model/Services/Checkout.php
+++ b/Model/Services/Checkout.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class Checkout
@@ -26,7 +25,7 @@ class Checkout extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::POST;
+        return \Laminas\Http\Request::METHOD_POST;
     }
 
     /**

--- a/Model/Services/Companies.php
+++ b/Model/Services/Companies.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class Companies
@@ -26,7 +25,7 @@ class Companies extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::GET;
+        return \Laminas\Http\Request::METHOD_GET;
     }
 
     /**

--- a/Model/Services/RemoveToCart.php
+++ b/Model/Services/RemoveToCart.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class RemoveToCart
@@ -26,7 +25,7 @@ class RemoveToCart extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::DELETE;
+        return \Laminas\Http\Request::METHOD_DELETE;
     }
 
     /**

--- a/Model/Services/SearchItem.php
+++ b/Model/Services/SearchItem.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class SearchItem
@@ -26,7 +25,7 @@ class SearchItem extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::GET;
+        return \Laminas\Http\Request::METHOD_GET;
     }
 
     /**

--- a/Model/Services/ShippingCalculate.php
+++ b/Model/Services/ShippingCalculate.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class ShippingCalculate
@@ -26,7 +25,7 @@ class ShippingCalculate extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::POST;
+        return \Laminas\Http\Request::METHOD_POST;
     }
 
     /**

--- a/Model/Services/Stores.php
+++ b/Model/Services/Stores.php
@@ -6,7 +6,6 @@ use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\HttpClientInterface;
 use MelhorEnvio\Quote\Api\StoreInterface;
 use MelhorEnvio\Quote\Helper\Data as Helper;
-use Zend_Http_Client;
 
 
 class Stores extends AbstractService implements StoreInterface
@@ -32,7 +31,7 @@ class Stores extends AbstractService implements StoreInterface
 
     public function getMethod(): string
     {
-        return Zend_Http_Client::GET;
+        return \Laminas\Http\Request::METHOD_GET;
     }
 
     public function doRequest(): HttpResponseInterface

--- a/Model/Services/TagGenerate.php
+++ b/Model/Services/TagGenerate.php
@@ -5,7 +5,6 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
 
 /**
  * Class TagGenerate
@@ -26,7 +25,7 @@ class TagGenerate extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::POST;
+        return \Laminas\Http\Request::METHOD_POST;
     }
 
     /**

--- a/Model/Services/TagPreview.php
+++ b/Model/Services/TagPreview.php
@@ -5,7 +5,7 @@ namespace MelhorEnvio\Quote\Model\Services;
 use Magento\Framework\Exception\LocalizedException;
 use MelhorEnvio\Quote\Api\Data\HttpResponseInterface;
 use MelhorEnvio\Quote\Api\ServiceInterface;
-use Zend_Http_Client;
+use \Laminas\Http\Request;
 
 /**
  * Class TagPreview
@@ -26,7 +26,7 @@ class TagPreview extends AbstractService implements ServiceInterface
      */
     public function getMethod(): string
     {
-        return Zend_Http_Client::POST;
+        return \Laminas\Http\Request::METHOD_POST;
     }
 
     /**


### PR DESCRIPTION
Bugs no 2.4.6:

A partir do magento2.4.6, um pacote está obsoleto no Magento, o do Zend_Http, porque está em desuso. Com isso, foi necessário a substituição por a do Laminas. Os ajustes eram pontuais, não era de um nível complexo, porém a nova atualização e correção só vai servir para versões do Magento superior ou igual  a versão 2.4.6. 

Atualizações que foram feitas:
- Substituição das classes do Zend para Laminas.
- passar o Laminas\Http\Client diretamente no Construtor em Model/Services/Client/ZendClient.php.
- Substituição de alguns nomes de métodos.

Atenciosamente,

Bruno Alves